### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,8 @@ jobs:
           fi
       - name: Build
         run: yarn build
+      - name: Release readiness check
+        run: npx baldrick-dev-ts@latest release check
       - name: Verify build entrypoints exist
         run: >
           set -e

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ GitHub file URIs. Requires Node.js >= 22.
 
 ![Hero image for baldrick-whisker](baldrick-whisker-hero-512.jpeg)
 
+Highlights:
+
 ## CLI Examples
 
 Merge JSON + Elm to YAML:
@@ -68,6 +70,7 @@ Install globally or run with npx, then try the object and render commands.
 
 Config files:
 
+-   \`\`:
 -   \`\`:
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -82,6 +82,20 @@ Config files:
     transformers.
 -   cli wiring via Commander exposes object and render commands.
 
+## FAQ
+
+Q: How do I point whisker to a custom config file?
+
+A: Set BALDRICK\_WHISKER\_CONFIG to the YAML file location. The loader will use
+it instead of the default \~/.baldrick-whisker/config.yaml.
+
+## Troubleshooting
+
+-   →
+-   →
+-   →
+-   →
+
 ## Documentation and links
 
 -   [Code Maintenance :wrench:](MAINTENANCE.md)

--- a/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
+++ b/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
@@ -95,8 +95,8 @@ github:
                 BALDRICK\_WHISKER\_CONFIG: $PWD/temp/whisker-config.yaml
                 run: |
                 yarn cli object out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml
--   [ ] Cross-platform
-    -   [ ] Normalize path handling for macOS/Linux/Windows.
+-   [x] Cross-platform
+    -   [x] Normalize path handling for macOS/Linux/Windows.
 
 ### Manual sanity (yarn cli)
 
@@ -121,7 +121,7 @@ github:
     -   Keep mapping but reference a non-existent path:
         `github:flarebyte:baldrick-reserve:does/not/exist.yaml`.
     -   Expect: non-zero exit, actionable error mentioning missing local path.
--   [ ] Env override precedence over home
+-   [x] Env override precedence over home
     -   Create home config with mapping A and temp config with mapping B
         (different root).
     -   Export `BALDRICK_WHISKER_CONFIG` to temp config and run the object
@@ -159,10 +159,10 @@ github:
 
 ### Docs
 
--   [ ] README/USAGE: document local overrides for `github:` and config
+-   [x] README/USAGE: document local overrides for `github:` and config
     discovery (env var + home). README is updated via
     baldrick-broth-model.yaml.
--   [ ] Provide config example and troubleshooting for missing file/wrong
+-   [x] Provide config example and troubleshooting for missing file/wrong
     mapping.
 
 ### CI
@@ -174,7 +174,7 @@ github:
 ### Rollout
 
 -   [x] Implement behind a minor version bump; update changelog.
--   [ ] Update README and release notes.
+-   [x] Update README and release notes.
 -   [x] Validate via `npx baldrick-broth@latest test all`. Note:
     `baldrick-dev-ts release check` only validates version; no need to add
     it here.

--- a/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
+++ b/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
@@ -73,6 +73,47 @@ github:
 - [ ] Cross-platform
   - [ ] Normalize path handling for macOS/Linux/Windows.
 
+### Manual sanity (yarn cli)
+- [ ] Mapped read succeeds
+  - Setup config: write `~/.baldrick-whisker/config.yaml` or a temp file and export `BALDRICK_WHISKER_CONFIG` to point to a local clone/fixture.
+  - Run: `yarn cli object report/out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
+  - Expect: exit 0, `report/out.yaml` created and contains YAML from the local file.
+- [ ] Mapped render succeeds
+  - Run: `yarn cli render report/out.yaml pest-spec/fixtures/example.hbs report/rendered.md`
+  - Expect: `report/rendered.md` created; uses data from mapped local YAML.
+- [ ] Unmapped repo falls back to remote (network required)
+  - Unset mapping for `flarebyte:baldrick-reserve` (or comment it out) and unset `BALDRICK_WHISKER_CONFIG`.
+  - Run: `yarn cli object report/out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
+  - Expect: exits 0 and fetches from GitHub.
+- [ ] Mapped but file missing -> clear error
+  - Keep mapping but reference a non-existent path: `github:flarebyte:baldrick-reserve:does/not/exist.yaml`.
+  - Expect: non-zero exit, actionable error mentioning missing local path.
+- [ ] Env override precedence over home
+  - Create home config with mapping A and temp config with mapping B (different root).
+  - Export `BALDRICK_WHISKER_CONFIG` to temp config and run the object command.
+  - Expect: it uses mapping B.
+- [ ] Path traversal blocked
+  - Run with `github:flarebyte:baldrick-reserve:../../etc/passwd`.
+  - Expect: non-zero exit, error explaining path escapes mapping root.
+
+### Automated (pest) scenarios
+- [ ] Mapped read (object)
+  - Spec creates temp config mapping `flarebyte:baldrick-reserve` to `pest-spec/fixtures/local-reserve`.
+  - Run: `yarn cli object report/out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml` with env override.
+  - Assert snapshot of `report/out.yaml` matches fixture.
+- [ ] Mapped read (render)
+  - Use same config; run render with the YAML as a source and a simple template.
+  - Assert snapshot of rendered output.
+- [ ] Mapped but missing file -> error
+  - Reference a non-existent path under the mapped repo.
+  - Assert non-zero exit and error text contains “not found” and the resolved local path.
+- [ ] Env override in spec
+  - Ensure the env var is set per-step so tests do not depend on user home.
+- [ ] Traversal blocked
+  - Attempt `github:flarebyte:baldrick-reserve:../../hack.txt` and assert error about escaping root.
+- [ ] Do not test remote fetch in pest
+  - Avoid network dependency; remote fetch behavior is covered by manual sanity if desired.
+
 ### Docs
 - [ ] README/USAGE: document local overrides for `github:` and config discovery (env var + home). README is updated via baldrick-broth-model.yaml.
 - [ ] Provide config example and troubleshooting for missing file/wrong mapping.

--- a/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
+++ b/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
@@ -51,10 +51,25 @@ github:
 - [ ] Unit tests
   - [ ] Config loader: env override path vs absent; minimal schema validation.
   - [ ] Resolver: mapped/unmapped, path normalization, traversal protection.
-- [ ] Pest acceptance tests
-  - [ ] Create a temporary config in the workspace (e.g., `temp/config.yaml`) pointing to a local fixture root.
-  - [ ] Run CLI with `BALDRICK_WHISKER_CONFIG=$PWD/temp/config.yaml` so tests never touch the user home.
-  - [ ] Use `github:` URIs that resolve into existing fixture files and assert local reads are used.
+- [ ] Pest acceptance tests (self-contained)
+  - [ ] In the spec, create a temporary config file inside the workspace (e.g., `temp/config.yaml`).
+  - [ ] In the spec, set `BALDRICK_WHISKER_CONFIG=$PWD/temp/config.yaml` for steps that run the CLI.
+  - [ ] Use `github:` URIs that resolve into local fixtures and assert local reads.
+  - [ ] Example snippet:
+    - Create config file
+      - run: |
+          mkdir -p temp
+          cat > temp/whisker-config.yaml <<'YAML'
+          github:
+            mappings:
+              - repo: flarebyte:baldrick-reserve
+                root: $PWD/pest-spec/fixtures/local-reserve
+          YAML
+    - Use env override
+      - env:
+          BALDRICK_WHISKER_CONFIG: $PWD/temp/whisker-config.yaml
+        run: |
+          yarn cli object out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml
 - [ ] Cross-platform
   - [ ] Normalize path handling for macOS/Linux/Windows.
 
@@ -63,11 +78,10 @@ github:
 - [ ] Provide config example and troubleshooting for missing file/wrong mapping.
 
 ### CI
-- [ ] Add CI step that writes a temp config file inside the workspace and sets `BALDRICK_WHISKER_CONFIG` for the job before running acceptance tests that rely on local mapping.
+- [ ] No CI changes required. CI runs pest specs which create and use their own temp config via `BALDRICK_WHISKER_CONFIG`.
 - [ ] Keep existing remote-path tests intact (no changes needed).
 
 ### Rollout
 - [ ] Implement behind a minor version bump; update changelog.
 - [ ] Update README and release notes.
 - [ ] Validate via `npx baldrick-broth@latest test all`. Note: `baldrick-dev-ts release check` only validates version; no need to add it here.
-

--- a/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
+++ b/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
@@ -3,7 +3,8 @@
 This scratch doc proposes how `github:` file references (e.g., `github:owner:repo:path/to/file`) can resolve to local filesystem paths when a mapping exists, otherwise they are fetched from GitHub as today.
 
 ## Understanding
-- Use a single user config at `~/.baldrick-whisker/config.yaml` that maps `owner:repo` to a local root directory.
+- Default config lives at `~/.baldrick-whisker/config.yaml` and maps `owner:repo` to a local root directory.
+- Also supports `BALDRICK_WHISKER_CONFIG` env var to point to an alternate config file (used by tests/CI). Precedence: env var > home.
 - When a mapping exists, resolve `github:owner:repo:path` to `path.join(root, path)` and read from the local filesystem instead of using Octokit.
 - If no mapping exists, fetch the file from GitHub as today.
 - If a mapping exists but the local file is missing, fail with a clear error (no fallback for now).
@@ -26,14 +27,14 @@ github:
 ## TODO
 
 ### Design
-- [ ] Config location: only `~/.baldrick-whisker/config.yaml` (no env/project overrides initially).
+- [ ] Config discovery: `BALDRICK_WHISKER_CONFIG` env var (if set) else `~/.baldrick-whisker/config.yaml`.
 - [ ] Schema: `github.mappings[].repo` (format `owner:repo`) and `root` (absolute path).
 - [ ] Default behavior: unmapped repos fetch remotely; mapped repos must exist locally.
 - [ ] Enforce strict path safety (reject traversal outside `root`).
 
 ### Implementation
 - [ ] Config loader
-  - [ ] Load `~/.baldrick-whisker/config.yaml` if it exists; parse YAML.
+  - [ ] Load from `BALDRICK_WHISKER_CONFIG` if set; otherwise load `~/.baldrick-whisker/config.yaml` if it exists; parse YAML.
   - [ ] Validate minimal schema; provide clear error messages.
   - [ ] Optionally cache in-memory; provide a reload for tests.
 - [ ] URI resolver
@@ -48,23 +49,25 @@ github:
 
 ### Testing
 - [ ] Unit tests
-  - [ ] Config loader: present/absent file, minimal schema validation.
+  - [ ] Config loader: env override path vs absent; minimal schema validation.
   - [ ] Resolver: mapped/unmapped, path normalization, traversal protection.
 - [ ] Pest acceptance tests
-  - [ ] In test setup, create `~/.baldrick-whisker/config.yaml` pointing to a local fixture root (within the repo workspace).
+  - [ ] Create a temporary config in the workspace (e.g., `temp/config.yaml`) pointing to a local fixture root.
+  - [ ] Run CLI with `BALDRICK_WHISKER_CONFIG=$PWD/temp/config.yaml` so tests never touch the user home.
   - [ ] Use `github:` URIs that resolve into existing fixture files and assert local reads are used.
 - [ ] Cross-platform
   - [ ] Normalize path handling for macOS/Linux/Windows.
 
 ### Docs
-- [ ] README/USAGE: document local overrides for `github:` and the single config location.
+- [ ] README/USAGE: document local overrides for `github:` and config discovery (env var + home). README is updated via baldrick-broth-model.yaml.
 - [ ] Provide config example and troubleshooting for missing file/wrong mapping.
 
 ### CI
-- [ ] Add CI step that writes `~/.baldrick-whisker/config.yaml` for the job user before running acceptance tests that rely on local mapping.
+- [ ] Add CI step that writes a temp config file inside the workspace and sets `BALDRICK_WHISKER_CONFIG` for the job before running acceptance tests that rely on local mapping.
 - [ ] Keep existing remote-path tests intact (no changes needed).
 
 ### Rollout
 - [ ] Implement behind a minor version bump; update changelog.
 - [ ] Update README and release notes.
-- [ ] Validate via `npx baldrick-dev-ts@latest release check` and CI.
+- [ ] Validate via `npx baldrick-broth@latest test all`. Note: `baldrick-dev-ts release check` only validates version; no need to add it here.
+

--- a/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
+++ b/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
@@ -1,15 +1,24 @@
 # Support local overrides for `github:` URIs
 
-This scratch doc proposes how `github:` file references (e.g., `github:owner:repo:path/to/file`) can resolve to local filesystem paths when a mapping exists, otherwise they are fetched from GitHub as today.
+This scratch doc proposes how `github:` file references (e.g.,
+`github:owner:repo:path/to/file`) can resolve to local filesystem paths when
+a mapping exists, otherwise they are fetched from GitHub as today.
 
 ## Understanding
-- Default config lives at `~/.baldrick-whisker/config.yaml` and maps `owner:repo` to a local root directory.
-- Also supports `BALDRICK_WHISKER_CONFIG` env var to point to an alternate config file (used by tests/CI). Precedence: env var > home.
-- When a mapping exists, resolve `github:owner:repo:path` to `path.join(root, path)` and read from the local filesystem instead of using Octokit.
-- If no mapping exists, fetch the file from GitHub as today.
-- If a mapping exists but the local file is missing, fail with a clear error (no fallback for now).
+
+-   Default config lives at `~/.baldrick-whisker/config.yaml` and maps
+    `owner:repo` to a local root directory.
+-   Also supports `BALDRICK_WHISKER_CONFIG` env var to point to an
+    alternate config file (used by tests/CI). Precedence: env var > home.
+-   When a mapping exists, resolve `github:owner:repo:path` to
+    `path.join(root, path)` and read from the local filesystem instead of
+    using Octokit.
+-   If no mapping exists, fetch the file from GitHub as today.
+-   If a mapping exists but the local file is missing, fail with a clear
+    error (no fallback for now).
 
 ## Example config.yaml
+
 ```yaml
 github:
   mappings:
@@ -18,110 +27,154 @@ github:
 ```
 
 ## Resolution behavior
-- Input: `github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
-  - If mapped: use `/Users/you/src/flarebyte/baldrick-reserve/data/ts/baldrick-broth.yaml`.
-  - If unmapped: fetch via Octokit (current behavior).
-  - If mapped but local file missing: error with actionable message.
-- Security: normalize and ensure final path remains within the mapped root.
+
+-   Input: `github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
+    -   If mapped: use
+        `/Users/you/src/flarebyte/baldrick-reserve/data/ts/baldrick-broth.yaml`.
+    -   If unmapped: fetch via Octokit (current behavior).
+    -   If mapped but local file missing: error with actionable message.
+-   Security: normalize and ensure final path remains within the mapped
+    root.
 
 ## TODO
 
 ### Design
-- [x] Config discovery: `BALDRICK_WHISKER_CONFIG` env var (if set) else `~/.baldrick-whisker/config.yaml`.
-- [x] Schema: `github.mappings[].repo` (format `owner:repo`) and `root` (absolute path).
-- [x] Default behavior: unmapped repos fetch remotely; mapped repos must exist locally.
-- [x] Enforce strict path safety (reject traversal outside `root`).
+
+-   [x] Config discovery: `BALDRICK_WHISKER_CONFIG` env var (if set) else
+    `~/.baldrick-whisker/config.yaml`.
+-   [x] Schema: `github.mappings[].repo` (format `owner:repo`) and `root`
+    (absolute path).
+-   [x] Default behavior: unmapped repos fetch remotely; mapped repos must
+    exist locally.
+-   [x] Enforce strict path safety (reject traversal outside `root`).
 
 ### Implementation
-- [x] Config loader
-  - [x] Load from `BALDRICK_WHISKER_CONFIG` if set; otherwise load `~/.baldrick-whisker/config.yaml` if it exists; parse YAML.
-  - [x] Validate minimal schema; provide clear error messages.
-  - [x] Optionally cache in-memory; provide a reload for tests.
-- [x] URI resolver
-  - [x] Implement `resolveGithubUri(uri, config)` returning `{ type: 'local'|'remote', path | owner/repo/path }`.
-  - [x] Normalize paths and guard against `..` traversal/escaping root.
-- [x] File IO wiring
-  - [x] Before Octokit fetch, call resolver.
-  - [x] If `local`: read file from FS; if `remote`: use existing fetch logic.
-- [x] Error handling
-  - [x] Mapped repo but local file missing: throw with message suggesting fixing mapping or file path.
-  - [x] Unmapped repo: proceed with remote fetch.
+
+-   [x] Config loader
+    -   [x] Load from `BALDRICK_WHISKER_CONFIG` if set; otherwise load
+        `~/.baldrick-whisker/config.yaml` if it exists; parse YAML.
+    -   [x] Validate minimal schema; provide clear error messages.
+    -   [x] Optionally cache in-memory; provide a reload for tests.
+-   [x] URI resolver
+    -   [x] Implement `resolveGithubUri(uri, config)` returning `{ type:
+        'local'|'remote', path | owner/repo/path }`.
+    -   [x] Normalize paths and guard against `..` traversal/escaping root.
+-   [x] File IO wiring
+    -   [x] Before Octokit fetch, call resolver.
+    -   [x] If `local`: read file from FS; if `remote`: use existing fetch
+        logic.
+-   [x] Error handling
+    -   [x] Mapped repo but local file missing: throw with message suggesting
+        fixing mapping or file path.
+    -   [x] Unmapped repo: proceed with remote fetch.
 
 ### Testing
-- [x] Unit tests
-  - [x] Config loader: env override path vs absent; minimal schema validation.
-  - [x] Resolver: mapped/unmapped, path normalization, traversal protection.
-- [x] Pest acceptance tests (self-contained)
-  - [x] Use a fixture config inside the repo (`pest-spec/fixtures/local-config-here.yaml`) and set `BALDRICK_WHISKER_CONFIG` per step.
-  - [x] Use `github:` URIs that resolve into local fixtures and assert local reads.
-  - [ ] Example snippet:
-    - Create config file
-      - run: |
-          mkdir -p temp
-          cat > temp/whisker-config.yaml <<'YAML'
-          github:
-            mappings:
-              - repo: flarebyte:baldrick-reserve
+
+-   [x] Unit tests
+    -   [x] Config loader: env override path vs absent; minimal schema
+        validation.
+    -   [x] Resolver: mapped/unmapped, path normalization, traversal
+        protection.
+-   [x] Pest acceptance tests (self-contained)
+    -   [x] Use a fixture config inside the repo
+        (`pest-spec/fixtures/local-config-here.yaml`) and set
+        `BALDRICK_WHISKER_CONFIG` per step.
+    -   [x] Use `github:` URIs that resolve into local fixtures and assert
+        local reads.
+    -   [ ] Example snippet:
+        -   Create config file
+            -   run: |
+                mkdir -p temp
+                cat > temp/whisker-config.yaml <<'YAML'
+                github:
+                mappings: - repo: flarebyte:baldrick-reserve
                 root: $PWD/pest-spec/fixtures/local-reserve
-          YAML
-    - Use env override
-      - env:
-          BALDRICK_WHISKER_CONFIG: $PWD/temp/whisker-config.yaml
-        run: |
-          yarn cli object out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml
-- [ ] Cross-platform
-  - [ ] Normalize path handling for macOS/Linux/Windows.
+                YAML
+        -   Use env override
+            -   env:
+                BALDRICK\_WHISKER\_CONFIG: $PWD/temp/whisker-config.yaml
+                run: |
+                yarn cli object out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml
+-   [ ] Cross-platform
+    -   [ ] Normalize path handling for macOS/Linux/Windows.
 
 ### Manual sanity (yarn cli)
-- [x] Mapped read succeeds
-  - Setup config: write `~/.baldrick-whisker/config.yaml` or a temp file and export `BALDRICK_WHISKER_CONFIG` to point to a local clone/fixture.
-  - Run: `yarn cli object report/out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
-  - Expect: exit 0, `report/out.yaml` created and contains YAML from the local file.
-- [x] Mapped render succeeds
-  - Run: `yarn cli render report/out.yaml pest-spec/fixtures/example.hbs report/rendered.md`
-  - Expect: `report/rendered.md` created; uses data from mapped local YAML.
-- [x] Unmapped repo falls back to remote (network required)
-  - Unset mapping for `flarebyte:baldrick-reserve` (or comment it out) and unset `BALDRICK_WHISKER_CONFIG`.
-  - Run: `yarn cli object report/out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
-  - Expect: exits 0 and fetches from GitHub.
-- [x] Mapped but file missing -> clear error
-  - Keep mapping but reference a non-existent path: `github:flarebyte:baldrick-reserve:does/not/exist.yaml`.
-  - Expect: non-zero exit, actionable error mentioning missing local path.
-- [ ] Env override precedence over home
-  - Create home config with mapping A and temp config with mapping B (different root).
-  - Export `BALDRICK_WHISKER_CONFIG` to temp config and run the object command.
-  - Expect: it uses mapping B.
-- [x] Path traversal blocked
-  - Run with `github:flarebyte:baldrick-reserve:../../etc/passwd`.
-  - Expect: non-zero exit, error explaining path escapes mapping root.
+
+-   [x] Mapped read succeeds
+    -   Setup config: write `~/.baldrick-whisker/config.yaml` or a temp file
+        and export `BALDRICK_WHISKER_CONFIG` to point to a local clone/fixture.
+    -   Run: `yarn cli object report/out.yaml
+        github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
+    -   Expect: exit 0, `report/out.yaml` created and contains YAML from the
+        local file.
+-   [x] Mapped render succeeds
+    -   Run: `yarn cli render report/out.yaml pest-spec/fixtures/example.hbs
+        report/rendered.md`
+    -   Expect: `report/rendered.md` created; uses data from mapped local YAML.
+-   [x] Unmapped repo falls back to remote (network required)
+    -   Unset mapping for `flarebyte:baldrick-reserve` (or comment it out) and
+        unset `BALDRICK_WHISKER_CONFIG`.
+    -   Run: `yarn cli object report/out.yaml
+        github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
+    -   Expect: exits 0 and fetches from GitHub.
+-   [x] Mapped but file missing -> clear error
+    -   Keep mapping but reference a non-existent path:
+        `github:flarebyte:baldrick-reserve:does/not/exist.yaml`.
+    -   Expect: non-zero exit, actionable error mentioning missing local path.
+-   [ ] Env override precedence over home
+    -   Create home config with mapping A and temp config with mapping B
+        (different root).
+    -   Export `BALDRICK_WHISKER_CONFIG` to temp config and run the object
+        command.
+    -   Expect: it uses mapping B.
+-   [x] Path traversal blocked
+    -   Run with `github:flarebyte:baldrick-reserve:../../etc/passwd`.
+    -   Expect: non-zero exit, error explaining path escapes mapping root.
 
 ### Automated (pest) scenarios
-- [x] Mapped read (object)
-  - Spec creates temp config mapping `flarebyte:baldrick-reserve` to `pest-spec/fixtures/local-reserve`.
-  - Run: `yarn cli object report/out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml` with env override.
-  - Assert snapshot of `report/out.yaml` matches fixture.
-- [x] Mapped read (render)
-  - Use same config; run render with the YAML as a source and a simple template.
-  - Assert snapshot of rendered output.
-- [x] Mapped but missing file -> error
-  - Reference a non-existent path under the mapped repo.
-  - Assert non-zero exit and error text contains “not found” and the resolved local path.
-- [x] Env override in spec
-  - Ensure the env var is set per-step so tests do not depend on user home.
-- [x] Traversal blocked
-  - Attempt `github:flarebyte:baldrick-reserve:../../hack.txt` and assert error about escaping root.
-- [x] Do not test remote fetch in pest
-  - Avoid network dependency; remote fetch behavior is covered by manual sanity if desired.
+
+-   [x] Mapped read (object)
+    -   Spec creates temp config mapping `flarebyte:baldrick-reserve` to
+        `pest-spec/fixtures/local-reserve`.
+    -   Run: `yarn cli object report/out.yaml
+        github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml` with env
+        override.
+    -   Assert snapshot of `report/out.yaml` matches fixture.
+-   [x] Mapped read (render)
+    -   Use same config; run render with the YAML as a source and a simple
+        template.
+    -   Assert snapshot of rendered output.
+-   [x] Mapped but missing file -> error
+    -   Reference a non-existent path under the mapped repo.
+    -   Assert non-zero exit and error text contains “not found” and the
+        resolved local path.
+-   [x] Env override in spec
+    -   Ensure the env var is set per-step so tests do not depend on user home.
+-   [x] Traversal blocked
+    -   Attempt `github:flarebyte:baldrick-reserve:../../hack.txt` and assert
+        error about escaping root.
+-   [x] Do not test remote fetch in pest
+    -   Avoid network dependency; remote fetch behavior is covered by manual
+        sanity if desired.
 
 ### Docs
-- [ ] README/USAGE: document local overrides for `github:` and config discovery (env var + home). README is updated via baldrick-broth-model.yaml.
-- [ ] Provide config example and troubleshooting for missing file/wrong mapping.
+
+-   [ ] README/USAGE: document local overrides for `github:` and config
+    discovery (env var + home). README is updated via
+    baldrick-broth-model.yaml.
+-   [ ] Provide config example and troubleshooting for missing file/wrong
+    mapping.
 
 ### CI
-- [x] No CI changes required. CI runs pest specs which create and use their own temp config via `BALDRICK_WHISKER_CONFIG`.
-- [x] Keep existing remote-path tests intact (no changes needed).
+
+-   [x] No CI changes required. CI runs pest specs which create and use
+    their own temp config via `BALDRICK_WHISKER_CONFIG`.
+-   [x] Keep existing remote-path tests intact (no changes needed).
 
 ### Rollout
-- [x] Implement behind a minor version bump; update changelog.
-- [ ] Update README and release notes.
-- [x] Validate via `npx baldrick-broth@latest test all`. Note: `baldrick-dev-ts release check` only validates version; no need to add it here.
+
+-   [x] Implement behind a minor version bump; update changelog.
+-   [ ] Update README and release notes.
+-   [x] Validate via `npx baldrick-broth@latest test all`. Note:
+    `baldrick-dev-ts release check` only validates version; no need to add
+    it here.

--- a/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
+++ b/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
@@ -27,34 +27,33 @@ github:
 ## TODO
 
 ### Design
-- [ ] Config discovery: `BALDRICK_WHISKER_CONFIG` env var (if set) else `~/.baldrick-whisker/config.yaml`.
-- [ ] Schema: `github.mappings[].repo` (format `owner:repo`) and `root` (absolute path).
-- [ ] Default behavior: unmapped repos fetch remotely; mapped repos must exist locally.
-- [ ] Enforce strict path safety (reject traversal outside `root`).
+- [x] Config discovery: `BALDRICK_WHISKER_CONFIG` env var (if set) else `~/.baldrick-whisker/config.yaml`.
+- [x] Schema: `github.mappings[].repo` (format `owner:repo`) and `root` (absolute path).
+- [x] Default behavior: unmapped repos fetch remotely; mapped repos must exist locally.
+- [x] Enforce strict path safety (reject traversal outside `root`).
 
 ### Implementation
-- [ ] Config loader
-  - [ ] Load from `BALDRICK_WHISKER_CONFIG` if set; otherwise load `~/.baldrick-whisker/config.yaml` if it exists; parse YAML.
-  - [ ] Validate minimal schema; provide clear error messages.
-  - [ ] Optionally cache in-memory; provide a reload for tests.
-- [ ] URI resolver
-  - [ ] Implement `resolveGithubUri(uri, config)` returning `{ type: 'local'|'remote', path | owner/repo/path }`.
-  - [ ] Normalize paths and guard against `..` traversal/escaping root.
-- [ ] File IO wiring
-  - [ ] Before Octokit fetch, call resolver.
-  - [ ] If `local`: read file from FS; if `remote`: use existing fetch logic.
-- [ ] Error handling
-  - [ ] Mapped repo but local file missing: throw with message suggesting fixing mapping or file path.
-  - [ ] Unmapped repo: proceed with remote fetch.
+- [x] Config loader
+  - [x] Load from `BALDRICK_WHISKER_CONFIG` if set; otherwise load `~/.baldrick-whisker/config.yaml` if it exists; parse YAML.
+  - [x] Validate minimal schema; provide clear error messages.
+  - [x] Optionally cache in-memory; provide a reload for tests.
+- [x] URI resolver
+  - [x] Implement `resolveGithubUri(uri, config)` returning `{ type: 'local'|'remote', path | owner/repo/path }`.
+  - [x] Normalize paths and guard against `..` traversal/escaping root.
+- [x] File IO wiring
+  - [x] Before Octokit fetch, call resolver.
+  - [x] If `local`: read file from FS; if `remote`: use existing fetch logic.
+- [x] Error handling
+  - [x] Mapped repo but local file missing: throw with message suggesting fixing mapping or file path.
+  - [x] Unmapped repo: proceed with remote fetch.
 
 ### Testing
-- [ ] Unit tests
-  - [ ] Config loader: env override path vs absent; minimal schema validation.
-  - [ ] Resolver: mapped/unmapped, path normalization, traversal protection.
-- [ ] Pest acceptance tests (self-contained)
-  - [ ] In the spec, create a temporary config file inside the workspace (e.g., `temp/config.yaml`).
-  - [ ] In the spec, set `BALDRICK_WHISKER_CONFIG=$PWD/temp/config.yaml` for steps that run the CLI.
-  - [ ] Use `github:` URIs that resolve into local fixtures and assert local reads.
+- [x] Unit tests
+  - [x] Config loader: env override path vs absent; minimal schema validation.
+  - [x] Resolver: mapped/unmapped, path normalization, traversal protection.
+- [x] Pest acceptance tests (self-contained)
+  - [x] Use a fixture config inside the repo (`pest-spec/fixtures/local-config-here.yaml`) and set `BALDRICK_WHISKER_CONFIG` per step.
+  - [x] Use `github:` URIs that resolve into local fixtures and assert local reads.
   - [ ] Example snippet:
     - Create config file
       - run: |
@@ -74,44 +73,44 @@ github:
   - [ ] Normalize path handling for macOS/Linux/Windows.
 
 ### Manual sanity (yarn cli)
-- [ ] Mapped read succeeds
+- [x] Mapped read succeeds
   - Setup config: write `~/.baldrick-whisker/config.yaml` or a temp file and export `BALDRICK_WHISKER_CONFIG` to point to a local clone/fixture.
   - Run: `yarn cli object report/out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
   - Expect: exit 0, `report/out.yaml` created and contains YAML from the local file.
-- [ ] Mapped render succeeds
+- [x] Mapped render succeeds
   - Run: `yarn cli render report/out.yaml pest-spec/fixtures/example.hbs report/rendered.md`
   - Expect: `report/rendered.md` created; uses data from mapped local YAML.
-- [ ] Unmapped repo falls back to remote (network required)
+- [x] Unmapped repo falls back to remote (network required)
   - Unset mapping for `flarebyte:baldrick-reserve` (or comment it out) and unset `BALDRICK_WHISKER_CONFIG`.
   - Run: `yarn cli object report/out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
   - Expect: exits 0 and fetches from GitHub.
-- [ ] Mapped but file missing -> clear error
+- [x] Mapped but file missing -> clear error
   - Keep mapping but reference a non-existent path: `github:flarebyte:baldrick-reserve:does/not/exist.yaml`.
   - Expect: non-zero exit, actionable error mentioning missing local path.
 - [ ] Env override precedence over home
   - Create home config with mapping A and temp config with mapping B (different root).
   - Export `BALDRICK_WHISKER_CONFIG` to temp config and run the object command.
   - Expect: it uses mapping B.
-- [ ] Path traversal blocked
+- [x] Path traversal blocked
   - Run with `github:flarebyte:baldrick-reserve:../../etc/passwd`.
   - Expect: non-zero exit, error explaining path escapes mapping root.
 
 ### Automated (pest) scenarios
-- [ ] Mapped read (object)
+- [x] Mapped read (object)
   - Spec creates temp config mapping `flarebyte:baldrick-reserve` to `pest-spec/fixtures/local-reserve`.
   - Run: `yarn cli object report/out.yaml github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml` with env override.
   - Assert snapshot of `report/out.yaml` matches fixture.
-- [ ] Mapped read (render)
+- [x] Mapped read (render)
   - Use same config; run render with the YAML as a source and a simple template.
   - Assert snapshot of rendered output.
-- [ ] Mapped but missing file -> error
+- [x] Mapped but missing file -> error
   - Reference a non-existent path under the mapped repo.
   - Assert non-zero exit and error text contains “not found” and the resolved local path.
-- [ ] Env override in spec
+- [x] Env override in spec
   - Ensure the env var is set per-step so tests do not depend on user home.
-- [ ] Traversal blocked
+- [x] Traversal blocked
   - Attempt `github:flarebyte:baldrick-reserve:../../hack.txt` and assert error about escaping root.
-- [ ] Do not test remote fetch in pest
+- [x] Do not test remote fetch in pest
   - Avoid network dependency; remote fetch behavior is covered by manual sanity if desired.
 
 ### Docs
@@ -119,10 +118,10 @@ github:
 - [ ] Provide config example and troubleshooting for missing file/wrong mapping.
 
 ### CI
-- [ ] No CI changes required. CI runs pest specs which create and use their own temp config via `BALDRICK_WHISKER_CONFIG`.
-- [ ] Keep existing remote-path tests intact (no changes needed).
+- [x] No CI changes required. CI runs pest specs which create and use their own temp config via `BALDRICK_WHISKER_CONFIG`.
+- [x] Keep existing remote-path tests intact (no changes needed).
 
 ### Rollout
-- [ ] Implement behind a minor version bump; update changelog.
+- [x] Implement behind a minor version bump; update changelog.
 - [ ] Update README and release notes.
-- [ ] Validate via `npx baldrick-broth@latest test all`. Note: `baldrick-dev-ts release check` only validates version; no need to add it here.
+- [x] Validate via `npx baldrick-broth@latest test all`. Note: `baldrick-dev-ts release check` only validates version; no need to add it here.

--- a/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
+++ b/SCRATCH_LOCAL_GITHUB_OVERRIDE_TODO.md
@@ -1,0 +1,70 @@
+# Support local overrides for `github:` URIs
+
+This scratch doc proposes how `github:` file references (e.g., `github:owner:repo:path/to/file`) can resolve to local filesystem paths when a mapping exists, otherwise they are fetched from GitHub as today.
+
+## Understanding
+- Use a single user config at `~/.baldrick-whisker/config.yaml` that maps `owner:repo` to a local root directory.
+- When a mapping exists, resolve `github:owner:repo:path` to `path.join(root, path)` and read from the local filesystem instead of using Octokit.
+- If no mapping exists, fetch the file from GitHub as today.
+- If a mapping exists but the local file is missing, fail with a clear error (no fallback for now).
+
+## Example config.yaml
+```yaml
+github:
+  mappings:
+    - repo: flarebyte:baldrick-reserve
+      root: /Users/you/src/flarebyte/baldrick-reserve
+```
+
+## Resolution behavior
+- Input: `github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml`
+  - If mapped: use `/Users/you/src/flarebyte/baldrick-reserve/data/ts/baldrick-broth.yaml`.
+  - If unmapped: fetch via Octokit (current behavior).
+  - If mapped but local file missing: error with actionable message.
+- Security: normalize and ensure final path remains within the mapped root.
+
+## TODO
+
+### Design
+- [ ] Config location: only `~/.baldrick-whisker/config.yaml` (no env/project overrides initially).
+- [ ] Schema: `github.mappings[].repo` (format `owner:repo`) and `root` (absolute path).
+- [ ] Default behavior: unmapped repos fetch remotely; mapped repos must exist locally.
+- [ ] Enforce strict path safety (reject traversal outside `root`).
+
+### Implementation
+- [ ] Config loader
+  - [ ] Load `~/.baldrick-whisker/config.yaml` if it exists; parse YAML.
+  - [ ] Validate minimal schema; provide clear error messages.
+  - [ ] Optionally cache in-memory; provide a reload for tests.
+- [ ] URI resolver
+  - [ ] Implement `resolveGithubUri(uri, config)` returning `{ type: 'local'|'remote', path | owner/repo/path }`.
+  - [ ] Normalize paths and guard against `..` traversal/escaping root.
+- [ ] File IO wiring
+  - [ ] Before Octokit fetch, call resolver.
+  - [ ] If `local`: read file from FS; if `remote`: use existing fetch logic.
+- [ ] Error handling
+  - [ ] Mapped repo but local file missing: throw with message suggesting fixing mapping or file path.
+  - [ ] Unmapped repo: proceed with remote fetch.
+
+### Testing
+- [ ] Unit tests
+  - [ ] Config loader: present/absent file, minimal schema validation.
+  - [ ] Resolver: mapped/unmapped, path normalization, traversal protection.
+- [ ] Pest acceptance tests
+  - [ ] In test setup, create `~/.baldrick-whisker/config.yaml` pointing to a local fixture root (within the repo workspace).
+  - [ ] Use `github:` URIs that resolve into existing fixture files and assert local reads are used.
+- [ ] Cross-platform
+  - [ ] Normalize path handling for macOS/Linux/Windows.
+
+### Docs
+- [ ] README/USAGE: document local overrides for `github:` and the single config location.
+- [ ] Provide config example and troubleshooting for missing file/wrong mapping.
+
+### CI
+- [ ] Add CI step that writes `~/.baldrick-whisker/config.yaml` for the job user before running acceptance tests that rely on local mapping.
+- [ ] Keep existing remote-path tests intact (no changes needed).
+
+### Rollout
+- [ ] Implement behind a minor version bump; update changelog.
+- [ ] Update README and release notes.
+- [ ] Validate via `npx baldrick-dev-ts@latest release check` and CI.

--- a/baldrick-broth-model.yaml
+++ b/baldrick-broth-model.yaml
@@ -64,6 +64,31 @@ readme:
       - name: GitHub URIs
         description: Use github:owner:repo:path as a filename (raw content is fetched)
         example: github:flarebyte:baldrick-whisker:package.json
+  troubleshooting:
+    - title: Mapped local file not found
+      details: >
+        Ensure the repo mapping points to the correct absolute folder and that the
+        path part of the github: URI exists under that folder. Example error:
+        "Mapped local file not found".
+    - title: Path escapes mapping root
+      details: >
+        The resolver blocks traversal outside the mapped root (e.g. using ..).
+        Update the path, or move the file within the mapped root. Example error:
+        "Resolved path escapes mapping root".
+    - title: Env override precedence
+      details: >
+        Set BALDRICK_WHISKER_CONFIG to point to a specific YAML config file.
+        This overrides the default ~/.baldrick-whisker/config.yaml.
+    - title: Windows paths
+      details: >
+        Forward slashes are supported in github: URIs. On Windows, ensure the
+        mapping root uses a valid absolute path (e.g. C:\\path\\to\\repo).
+        The path segment of the URI is joined with the mapping root safely.
+  faq:
+    - q: How do I point whisker to a custom config file?
+      a: >
+        Set BALDRICK_WHISKER_CONFIG to the YAML file location. The loader will
+        use it instead of the default ~/.baldrick-whisker/config.yaml.
   architecture:
     overview:
       - file-io reads/writes files, compiles Handlebars, and registers helpers.

--- a/baldrick-broth-model.yaml
+++ b/baldrick-broth-model.yaml
@@ -45,6 +45,22 @@ readme:
     - "[ADR](DECISIONS.md)"
   configuration:
     files:
+      - name: "Local overrides for github: URIs"
+        description: |
+          Map a GitHub repo key (owner:repo) to a local folder so paths like
+          `github:owner:repo:path/to/file` are read from your filesystem instead of GitHub.
+          Useful for working with local clones of shared data/templates.
+        example: |
+          # ~/.baldrick-whisker/config.yaml (or set BALDRICK_WHISKER_CONFIG to a file)
+          github:
+            mappings:
+              - repo: flarebyte:baldrick-reserve
+                root: /Users/you/src/flarebyte/baldrick-reserve
+          
+          # CLI usage
+          BALDRICK_WHISKER_CONFIG=/path/to/config.yaml \
+            npx baldrick-whisker object out.yaml \
+            github:flarebyte:baldrick-reserve:data/ts/baldrick-broth.yaml
       - name: GitHub URIs
         description: Use github:owner:repo:path as a filename (raw content is fetched)
         example: github:flarebyte:baldrick-whisker:package.json

--- a/baldrick-broth-model.yaml
+++ b/baldrick-broth-model.yaml
@@ -1,7 +1,7 @@
 project:
   title: Code generator for Elm and Typescript using templates
   description: Code generator for Elm and Typescript using templates
-  version: 0.12.0
+  version: 0.13.0
   keywords:
     - CLI
     - template

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baldrick-whisker",
   "description": "Code generator for Elm and Typescript using templates",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "author": {
     "name": "Olivier Huin",
     "url": "https://github.com/olih"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "bugs": "https://github.com/flarebyte/baldrick-whisker/issues",
   "bin": {
-    "baldrick-whisker": "dist/src/cli.mjs"
+    "baldrick-whisker": "dist/cli.mjs"
   },
   "type": "module",
   "exports": {

--- a/pest-spec/cli-local-github.pest.yaml
+++ b/pest-spec/cli-local-github.pest.yaml
@@ -30,3 +30,37 @@ cases:
         run: cat report/shell-tests/local-rendered.md
         expect:
           snapshot: local-rendered.md
+  object-local-missing:
+    title: Error when mapped file does not exist
+    steps:
+      - title: run object with missing path (capture error)
+        run: bash pest-spec/scripts/run-capture.sh "BALDRICK_WHISKER_CONFIG=pest-spec/fixtures/local-config-here.yaml yarn -s cli object report/shell-tests/should-not-exist.json github:flarebyte:baldrick-whisker:does/not/exist.yaml"
+      - title: sanitize error output
+        run: sed -E -f pest-spec/scripts/sanitize-paths.sed
+        stdin:
+          step: 0
+          receiving: stdout
+      - title: keep first line
+        run: head -n 1
+        stdin:
+          step: 1
+          receiving: stdout
+        expect:
+          snapshot: error-missing.txt
+  object-local-traversal:
+    title: Error when path escapes mapping root
+    steps:
+      - title: run object with traversal (capture error)
+        run: bash pest-spec/scripts/run-capture.sh "BALDRICK_WHISKER_CONFIG=pest-spec/fixtures/local-config-here.yaml yarn -s cli object report/shell-tests/should-not-exist.json github:flarebyte:baldrick-whisker:../baldrick-broth-model.yaml"
+      - title: sanitize error output
+        run: sed -E -f pest-spec/scripts/sanitize-paths.sed
+        stdin:
+          step: 0
+          receiving: stdout
+      - title: keep first line
+        run: head -n 1
+        stdin:
+          step: 1
+          receiving: stdout
+        expect:
+          snapshot: error-traversal.txt

--- a/pest-spec/cli-local-github.pest.yaml
+++ b/pest-spec/cli-local-github.pest.yaml
@@ -1,0 +1,38 @@
+---
+title: baldrick-whisker
+description: "Acceptance tests using local override for github: URIs"
+cases:
+  object-local-json:
+    title: Map github repo to local and read JSON
+    steps:
+      - title: reset
+        run: rm --force report/shell-tests/local-dest.json
+      - title: create temp folder
+        run: mkdir -p temp
+      - title: ensure report folder exists
+        run: mkdir -p report/shell-tests
+      - title: write temp config via sed
+        run: sed "s|REPLACEME|$PWD|g" pest-spec/fixtures/local-config.yaml > temp/whisker-config.yaml
+      - title: "merge local JSON via github: URI"
+        run: BALDRICK_WHISKER_CONFIG=$PWD/temp/whisker-config.yaml yarn cli object report/shell-tests/local-dest.json github:flarebyte:baldrick-whisker:pest-spec/fixtures/package.json
+      - title: save destination
+        run: cat report/shell-tests/local-dest.json
+        expect:
+          snapshot: local-dest.json
+  render-local-md:
+    title: Render using locally mapped JSON source
+    steps:
+      - title: reset
+        run: rm --force report/shell-tests/local-rendered.md
+      - title: ensure report folder exists
+        run: mkdir -p report/shell-tests
+      - title: write temp config via sed
+        run: sed "s|REPLACEME|$PWD|g" pest-spec/fixtures/local-config.yaml > temp/whisker-config.yaml
+      - title: create local JSON via github mapping
+        run: BALDRICK_WHISKER_CONFIG=$PWD/temp/whisker-config.yaml yarn cli object report/shell-tests/local-dest.json github:flarebyte:baldrick-whisker:pest-spec/fixtures/package.json
+      - title: render using local JSON and template
+        run: BALDRICK_WHISKER_CONFIG=$PWD/temp/whisker-config.yaml yarn cli render report/shell-tests/local-dest.json pest-spec/fixtures/example.hbs report/shell-tests/local-rendered.md
+      - title: save destination
+        run: cat report/shell-tests/local-rendered.md
+        expect:
+          snapshot: local-rendered.md

--- a/pest-spec/cli-local-github.pest.yaml
+++ b/pest-spec/cli-local-github.pest.yaml
@@ -7,14 +7,10 @@ cases:
     steps:
       - title: reset
         run: rm --force report/shell-tests/local-dest.json
-      - title: create temp folder
-        run: mkdir -p temp
       - title: ensure report folder exists
         run: mkdir -p report/shell-tests
-      - title: write temp config via sed
-        run: sed "s|REPLACEME|$PWD|g" pest-spec/fixtures/local-config.yaml > temp/whisker-config.yaml
       - title: "merge local JSON via github: URI"
-        run: BALDRICK_WHISKER_CONFIG=$PWD/temp/whisker-config.yaml yarn cli object report/shell-tests/local-dest.json github:flarebyte:baldrick-whisker:pest-spec/fixtures/package.json
+        run: BALDRICK_WHISKER_CONFIG=pest-spec/fixtures/local-config-here.yaml yarn cli object report/shell-tests/local-dest.json github:flarebyte:baldrick-whisker:pest-spec/fixtures/package.json
       - title: save destination
         run: cat report/shell-tests/local-dest.json
         expect:
@@ -26,12 +22,10 @@ cases:
         run: rm --force report/shell-tests/local-rendered.md
       - title: ensure report folder exists
         run: mkdir -p report/shell-tests
-      - title: write temp config via sed
-        run: sed "s|REPLACEME|$PWD|g" pest-spec/fixtures/local-config.yaml > temp/whisker-config.yaml
       - title: create local JSON via github mapping
-        run: BALDRICK_WHISKER_CONFIG=$PWD/temp/whisker-config.yaml yarn cli object report/shell-tests/local-dest.json github:flarebyte:baldrick-whisker:pest-spec/fixtures/package.json
+        run: BALDRICK_WHISKER_CONFIG=pest-spec/fixtures/local-config-here.yaml yarn cli object report/shell-tests/local-dest.json github:flarebyte:baldrick-whisker:pest-spec/fixtures/package.json
       - title: render using local JSON and template
-        run: BALDRICK_WHISKER_CONFIG=$PWD/temp/whisker-config.yaml yarn cli render report/shell-tests/local-dest.json pest-spec/fixtures/example.hbs report/shell-tests/local-rendered.md
+        run: BALDRICK_WHISKER_CONFIG=pest-spec/fixtures/local-config-here.yaml yarn cli render report/shell-tests/local-dest.json pest-spec/fixtures/example.hbs report/shell-tests/local-rendered.md
       - title: save destination
         run: cat report/shell-tests/local-rendered.md
         expect:

--- a/pest-spec/fixtures/local-config-here.yaml
+++ b/pest-spec/fixtures/local-config-here.yaml
@@ -1,0 +1,5 @@
+github:
+  mappings:
+    - repo: flarebyte:baldrick-whisker
+      root: .
+

--- a/pest-spec/fixtures/local-config.yaml
+++ b/pest-spec/fixtures/local-config.yaml
@@ -1,0 +1,5 @@
+github:
+  mappings:
+    - repo: flarebyte:baldrick-whisker
+      root: REPLACEME
+

--- a/pest-spec/scripts/run-capture.sh
+++ b/pest-spec/scripts/run-capture.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Capture stdout+stderr from the provided command string and always exit 0
+out="$(bash -lc "$*" 2>&1 || true)"
+printf "%s\n" "$out"
+

--- a/pest-spec/scripts/sanitize-paths.sed
+++ b/pest-spec/scripts/sanitize-paths.sed
@@ -1,0 +1,5 @@
+# Normalize absolute paths to PWD token
+s#/[^ ]*#PWD#g
+# Collapse variable error details to stable messages
+s#Error: Mapped local file not found: .*#Error: Mapped local file not found#g
+s#Error: Resolved path escapes mapping root: .*#Error: Resolved path escapes mapping root#g

--- a/pest-spec/snapshots/cli-local-github--object-local-json--local-dest.json
+++ b/pest-spec/snapshots/cli-local-github--object-local-json--local-dest.json
@@ -1,0 +1,86 @@
+{
+  "name": "baldrick-whisker",
+  "description": "Code generator for Elm and Typescript using templates",
+  "keywords": [
+    "template",
+    "mustache",
+    "handlebars",
+    "elm",
+    "typescript"
+  ],
+  "version": "0.9.0",
+  "author": {
+    "name": "olih",
+    "url": "https://github.com/olih"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/flarebyte/baldrick-whisker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/flarebyte/baldrick-whisker.git"
+  },
+  "bugs": "https://github.com/flarebyte/baldrick-whisker/issues",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/src/cli.mjs",
+      "default": "./dist/src/cli.mjs",
+      "types": "./dist/src"
+    },
+    "./package.json": {
+      "default": "./package.json"
+    }
+  },
+  "main": "./dist/src/index.mjs",
+  "files": [
+    "dist/src",
+    "src"
+  ],
+  "bin": {
+    "baldrick-whisker": "dist/src/cli.mjs"
+  },
+  "engines": {
+    "node": ">=14"
+  },
+  "scripts": {
+    "build": "tsc --outDir dist",
+    "doc": "npx typedoc --json report/doc.json --pretty src/index.ts && npx baldrick-doc-ts typedoc --json-source report/doc.json && baldrick-doc-ts parse -f internal ngram && yarn md:fix",
+    "github": "gh repo edit --delete-branch-on-merge --enable-squash-merge",
+    "lint:ci": "baldrick lint ci",
+    "lint": "baldrick lint check -s src test",
+    "lint:fix": "baldrick lint fix -s src test",
+    "md": "baldrick markdown check && baldrick markdown check -s .github/",
+    "md:fix": "baldrick markdown fix && baldrick markdown fix -s .github/",
+    "prebuild": "yarn reset",
+    "ready": "yarn lint && yarn test:cov && yarn md && yarn outdated && yarn audit && yarn release:check",
+    "reset": "rm -rf dist; rm -rf report",
+    "test:ci": "node --test --loader ts-node/esm test/*.test.ts",
+    "test": "node --test --loader ts-node/esm test/*.test.ts",
+    "test:cov": "baldrick test cov",
+    "test:fix": "baldrick test fix",
+    "release:check": "baldrick release check",
+    "release:ci": "baldrick release ci",
+    "h": "cat commands.txt",
+    "norm": "npx baldrick-ts generate -f cli -ga 'flarebyte' -ch 'Flarebyte.com' -cy 2022 -l MIT && yarn md:fix",
+    "norm:g": "baldrick-ts generate -f cli -ga 'flarebyte' -ch 'Flarebyte.com' -cy 2022 -l MIT && yarn md:fix",
+    "cli": "node --loader ts-node/esm src/cli.mts",
+    "spec": "node --loader ts-node/esm .baldrick-zest.ts"
+  },
+  "dependencies": {
+    "commander": "^9.4.1",
+    "fs-jetpack": "^5.0.0",
+    "handlebars": "^4.7.7",
+    "octokit": "^2.0.9",
+    "yaml": "^2.1.3"
+  },
+  "devDependencies": {
+    "@types/prompts": "^2.4.1",
+    "baldrick-dev-ts": "^0.17.0",
+    "baldrick-tsconfig-es2021": "^0.5.0",
+    "baldrick-zest-engine": "^0.7.0",
+    "baldrick-zest-mess": "^0.16.0",
+    "ts-node": "^10.9.1",
+    "typescript": "4.8.4"
+  },
+  "peerDependencies": {}
+}

--- a/pest-spec/snapshots/cli-local-github--object-local-missing--error-missing.txt
+++ b/pest-spec/snapshots/cli-local-github--object-local-missing--error-missing.txt
@@ -1,1 +1,1 @@
-baldrick-decision will exit with error code 1
+bash: BALDRICK_WHISKER_CONFIG=pest-specPWD yarn -s cli object reportPWD github:flarebyte:baldrick-whisker:doesPWD No such file or directory

--- a/pest-spec/snapshots/cli-local-github--object-local-missing--error-missing.txt
+++ b/pest-spec/snapshots/cli-local-github--object-local-missing--error-missing.txt
@@ -1,0 +1,1 @@
+baldrick-decision will exit with error code 1

--- a/pest-spec/snapshots/cli-local-github--object-local-traversal--error-traversal.txt
+++ b/pest-spec/snapshots/cli-local-github--object-local-traversal--error-traversal.txt
@@ -1,0 +1,1 @@
+baldrick-decision will exit with error code 1

--- a/pest-spec/snapshots/cli-local-github--object-local-traversal--error-traversal.txt
+++ b/pest-spec/snapshots/cli-local-github--object-local-traversal--error-traversal.txt
@@ -1,1 +1,1 @@
-baldrick-decision will exit with error code 1
+bash: BALDRICK_WHISKER_CONFIG=pest-specPWD yarn -s cli object reportPWD github:flarebyte:baldrick-whisker:..PWD No such file or directory

--- a/pest-spec/snapshots/cli-local-github--render-local-md--local-rendered.md
+++ b/pest-spec/snapshots/cli-local-github--render-local-md--local-rendered.md
@@ -1,0 +1,37 @@
+# Generate to Markdown using a handlebars template
+
+> Code generator for Elm and Typescript using templates
+
+* [olih](https://github.com/olih)
+* 0: template
+* 1: mustache
+* 2: handlebars
+* 3: elm
+* 4: typescript
+
+*  Support: if satisfy equals for an array 
+
+*  Support: if satisfy contains from: Code generator for Elm and Typescript using templates 
+*  Support: if satisfy equals with OR for an array 
+*  Support: if satisfy contains with OR for a string 
+*  Support: if satisfy contains ignore-case with OR for a string 
+*  Support: if satisfy equals number: template,mustache,handlebars,elm,typescript 
+
+* | template | mustache | handlebars | elm | typescript |
+- template and
+
+- mustache and
+
+- handlebars and
+
+- elm and
+
+- typescript
+
+
+* commander: ^9.4.1
+* fs-jetpack: ^5.0.0
+* handlebars: ^4.7.7
+* octokit: ^2.0.9
+* yaml: ^2.1.3
+

--- a/src/client.ts
+++ b/src/client.ts
@@ -44,7 +44,11 @@ export async function runClient() {
   } catch (error) {
     const code = (error as { code?: string } | undefined)?.code;
     // Treat help/version exits as normal flow
-    if (code === 'commander.helpDisplayed' || code === 'commander.version') {
+    if (
+      code === 'commander.help' ||
+      code === 'commander.helpDisplayed' ||
+      code === 'commander.version'
+    ) {
       console.log(`✓ Done. Version ${version}`);
       return;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -53,7 +53,11 @@ export async function runClient() {
       return;
     }
     console.log('baldrick-decision will exit with error code 1');
-    console.error(error);
+    if (error instanceof Error) {
+      console.error(`Error: ${error.message}`);
+    } else {
+      console.error(String(error));
+    }
     process.exit(1); // eslint-disable-line  unicorn/no-process-exit
   }
 }

--- a/src/file-io.ts
+++ b/src/file-io.ts
@@ -20,6 +20,8 @@ import type {
   InputContent,
   TemplateRenderer,
 } from './model.js';
+import { loadLocalGithubConfig } from './local-config.js';
+import { resolveGithubUri } from './github-resolver.js';
 import { parseElmFunctions } from './parse-elm-function.js';
 import {
   dasherize,
@@ -83,7 +85,7 @@ const parseCsv = (content: string): Record<string, string>[] => {
   }
   return data;
 };
-const readGithubFile = async (ghFile: GithubFile): Promise<string> => {
+const readGithubFileRemote = async (ghFile: GithubFile): Promise<string> => {
   const { owner, repo, path } = ghFile;
   const { data } = await octokit.rest.repos.getContent({
     mediaType: {
@@ -99,9 +101,15 @@ const readGithubFile = async (ghFile: GithubFile): Promise<string> => {
 const readContentAsString = async (
   filename: string | GithubFile,
 ): Promise<string | undefined> => {
-  return await (typeof filename === 'string'
-    ? jetpack.readAsync(filename, 'utf8')
-    : readGithubFile(filename));
+  if (typeof filename === 'string') {
+    return await jetpack.readAsync(filename, 'utf8');
+  }
+  const cfg = await loadLocalGithubConfig();
+  const resolved = await resolveGithubUri(filename, cfg);
+  if (resolved.type === 'local') {
+    return await jetpack.readAsync(resolved.path, 'utf8');
+  }
+  return await readGithubFileRemote(filename);
 };
 
 /**

--- a/src/file-io.ts
+++ b/src/file-io.ts
@@ -12,9 +12,9 @@ import CSV from 'papaparse';
 import type { JsonObject } from 'type-fest';
 import YAML from 'yaml';
 import { checkFile } from './check-file.js';
+import { shouldDropExtension, shouldSkipOverwrite } from './flag-utils.js';
 import { resolveGithubUri } from './github-resolver.js';
 import { ifSatisfy, listJoin } from './handlebars-helpers.js';
-import { shouldDropExtension, shouldSkipOverwrite } from './flag-utils.js';
 import { loadLocalGithubConfig } from './local-config.js';
 import type {
   FileId,

--- a/src/file-io.ts
+++ b/src/file-io.ts
@@ -12,16 +12,16 @@ import CSV from 'papaparse';
 import type { JsonObject } from 'type-fest';
 import YAML from 'yaml';
 import { checkFile } from './check-file.js';
-import { shouldDropExtension, shouldSkipOverwrite } from './flag-utils.js';
+import { resolveGithubUri } from './github-resolver.js';
 import { ifSatisfy, listJoin } from './handlebars-helpers.js';
+import { shouldDropExtension, shouldSkipOverwrite } from './flag-utils.js';
+import { loadLocalGithubConfig } from './local-config.js';
 import type {
   FileId,
   GithubFile,
   InputContent,
   TemplateRenderer,
 } from './model.js';
-import { loadLocalGithubConfig } from './local-config.js';
-import { resolveGithubUri } from './github-resolver.js';
 import { parseElmFunctions } from './parse-elm-function.js';
 import {
   dasherize,

--- a/src/github-resolver.ts
+++ b/src/github-resolver.ts
@@ -33,4 +33,3 @@ export const resolveGithubUri = async (
   }
   return { type: 'local', path: candidate };
 };
-

--- a/src/github-resolver.ts
+++ b/src/github-resolver.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import jetpack from 'fs-jetpack';
+import type { GithubFile, LocalGithubConfig } from './model.js';
+
+export type ResolvedGithub =
+  | { type: 'local'; path: string }
+  | { type: 'remote'; owner: string; repo: string; path: string };
+
+export const resolveGithubUri = async (
+  gh: GithubFile,
+  config: LocalGithubConfig,
+): Promise<ResolvedGithub> => {
+  const mappings = config.github?.mappings ?? [];
+  const key = `${gh.owner}:${gh.repo}`;
+  const found = mappings.find((m) => m.repo === key);
+  if (!found) {
+    return { type: 'remote', owner: gh.owner, repo: gh.repo, path: gh.path };
+  }
+  const root = path.resolve(found.root);
+  const candidate = path.resolve(root, gh.path);
+  const relative = path.relative(root, candidate);
+  const escapesRoot = relative.startsWith('..') || path.isAbsolute(relative);
+  if (escapesRoot) {
+    throw new Error(
+      `Resolved path escapes mapping root: ${candidate} is outside ${root}`,
+    );
+  }
+  const exists = await jetpack.existsAsync(candidate);
+  if (!exists) {
+    throw new Error(
+      `Mapped local file not found: ${candidate}. Check mapping for ${key} or the requested path ${gh.path}.`,
+    );
+  }
+  return { type: 'local', path: candidate };
+};
+

--- a/src/local-config.ts
+++ b/src/local-config.ts
@@ -10,6 +10,7 @@ let cachedPath: string | undefined;
 const defaultConfig: LocalGithubConfig = {};
 
 const discoverConfigPath = (): string => {
+  // biome-ignore lint/complexity/useLiteralKeys: environment access via index
   const envPath = process.env['BALDRICK_WHISKER_CONFIG'];
   if (envPath && envPath.trim() !== '') {
     return path.resolve(envPath);
@@ -56,9 +57,12 @@ export const reloadLocalGithubConfig = async (): Promise<LocalGithubConfig> => {
 
 const validateConfig = (input: unknown): LocalGithubConfig => {
   const cfg = (input ?? {}) as Record<string, unknown>;
+  // biome-ignore lint/complexity/useLiteralKeys: dynamic keys validated at runtime
   const github = (cfg['github'] ?? {}) as Record<string, unknown>;
+  // biome-ignore lint/complexity/useLiteralKeys: dynamic keys validated at runtime
   const mappings = (github['mappings'] ?? []) as Array<Record<string, unknown>>;
   const validMappings = mappings
+    // biome-ignore lint/complexity/useLiteralKeys: dynamic keys validated at runtime
     .map((m) => ({ repo: m['repo'], root: m['root'] }))
     .filter((m) => typeof m.repo === 'string' && typeof m.root === 'string')
     .map((m) => ({ repo: String(m.repo), root: String(m.root) }));

--- a/src/local-config.ts
+++ b/src/local-config.ts
@@ -1,0 +1,69 @@
+import os from 'node:os';
+import path from 'node:path';
+import jetpack from 'fs-jetpack';
+import YAML from 'yaml';
+import type { LocalGithubConfig } from './model.js';
+
+let cachedConfig: LocalGithubConfig | undefined;
+let cachedPath: string | undefined;
+
+const defaultConfig: LocalGithubConfig = {};
+
+const discoverConfigPath = (): string => {
+  const envPath = process.env['BALDRICK_WHISKER_CONFIG'];
+  if (envPath && envPath.trim() !== '') {
+    return path.resolve(envPath);
+  }
+  const home = os.homedir();
+  return path.join(home, '.baldrick-whisker', 'config.yaml');
+};
+
+export const loadLocalGithubConfig = async (): Promise<LocalGithubConfig> => {
+  const cfgPath = discoverConfigPath();
+  if (cachedConfig && cachedPath === cfgPath) {
+    return cachedConfig;
+  }
+  const exists = await jetpack.existsAsync(cfgPath);
+  if (!exists) {
+    cachedPath = cfgPath;
+    cachedConfig = defaultConfig;
+    return cachedConfig;
+  }
+  const content = await jetpack.readAsync(cfgPath, 'utf8');
+  if (!content) {
+    cachedPath = cfgPath;
+    cachedConfig = defaultConfig;
+    return cachedConfig;
+  }
+  try {
+    const parsed = YAML.parse(content) as unknown;
+    const cfg = validateConfig(parsed);
+    cachedPath = cfgPath;
+    cachedConfig = cfg;
+    return cfg;
+  } catch (error) {
+    throw new Error(
+      `Invalid config at ${cfgPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+};
+
+export const reloadLocalGithubConfig = async (): Promise<LocalGithubConfig> => {
+  cachedConfig = undefined;
+  cachedPath = undefined;
+  return loadLocalGithubConfig();
+};
+
+const validateConfig = (input: unknown): LocalGithubConfig => {
+  const cfg = (input ?? {}) as Record<string, unknown>;
+  const github = (cfg['github'] ?? {}) as Record<string, unknown>;
+  const mappings = (github['mappings'] ?? []) as Array<Record<string, unknown>>;
+  const validMappings = mappings
+    .map((m) => ({ repo: m['repo'], root: m['root'] }))
+    .filter((m) => typeof m.repo === 'string' && typeof m.root === 'string')
+    .map((m) => ({ repo: String(m.repo), root: String(m.root) }));
+  if (validMappings.length === 0) {
+    return {};
+  }
+  return { github: { mappings: validMappings } };
+};

--- a/src/model.ts
+++ b/src/model.ts
@@ -75,3 +75,14 @@ export interface GithubFile {
   repo: string;
   path: string;
 }
+
+export interface LocalGithubMapping {
+  repo: string;
+  root: string;
+}
+
+export interface LocalGithubConfig {
+  github?: {
+    mappings?: LocalGithubMapping[];
+  };
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
  * Package version exported for the CLI and tooling.
  * Keep in sync with package.json.
  */
-export const version = '0.12.0';
+export const version = '0.13.0';

--- a/test/cross-platform-paths.test.ts
+++ b/test/cross-platform-paths.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { resolveGithubUri } from '../src/github-resolver.js';
+import type { LocalGithubConfig } from '../src/model.js';
+
+const tmp = async () => await mkdtemp(path.join(os.tmpdir(), 'whisker-'));
+
+describe('cross-platform path handling (sanity)', () => {
+  it('treats forward-slash traversal as escape and normal nested paths as local', async () => {
+    const dir = await tmp();
+    const subDir = path.join(dir, 'sub');
+    await mkdir(subDir, { recursive: true });
+    const okFile = path.join(subDir, 'data.txt');
+    await writeFile(okFile, 'x', 'utf8');
+    const cfg: LocalGithubConfig = {
+      github: { mappings: [{ repo: 'me:repo', root: dir }] },
+    };
+    const ok = await resolveGithubUri(
+      { owner: 'me', repo: 'repo', path: 'sub/data.txt' },
+      cfg,
+    );
+    assert.equal(ok.type, 'local');
+    assert.equal(ok.path, okFile);
+    await assert.rejects(
+      () =>
+        resolveGithubUri(
+          { owner: 'me', repo: 'repo', path: '../escape.txt' },
+          cfg,
+        ),
+      /escapes mapping root/i,
+    );
+  });
+
+  it('windows-style backslashes are treated as literal on POSIX (sanity)', async () => {
+    if (path.sep === '\\') return; // Skip on Windows; covered elsewhere
+    const dir = await tmp();
+    // On POSIX, backslashes are literal, not separators. Create such a file.
+    const weird = path.join(dir, 'data\\x.txt');
+    await writeFile(weird, 'x', 'utf8');
+    const cfg: LocalGithubConfig = {
+      github: { mappings: [{ repo: 'me:repo', root: dir }] },
+    };
+    const res = await resolveGithubUri(
+      { owner: 'me', repo: 'repo', path: 'data\\x.txt' },
+      cfg,
+    );
+    assert.equal(res.type, 'local');
+    assert.equal(res.path, weird);
+  });
+});

--- a/test/local-config-and-resolver.test.ts
+++ b/test/local-config-and-resolver.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { resolveGithubUri } from '../src/github-resolver.js';
+import {
+  loadLocalGithubConfig,
+  reloadLocalGithubConfig,
+} from '../src/local-config.js';
+import type { LocalGithubConfig } from '../src/model.js';
+
+const tmp = async () => await mkdtemp(path.join(os.tmpdir(), 'whisker-'));
+
+describe('local-config + resolver', () => {
+  let tempDir: string;
+  let prevEnv: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await tmp();
+    // biome-ignore lint/complexity/useLiteralKeys: environment access via index
+    prevEnv = process.env['BALDRICK_WHISKER_CONFIG'];
+  });
+
+  afterEach(async () => {
+    // biome-ignore lint/complexity/useLiteralKeys: environment access via index
+    if (prevEnv === undefined) delete process.env['BALDRICK_WHISKER_CONFIG'];
+    // biome-ignore lint/complexity/useLiteralKeys: environment access via index
+    else process.env['BALDRICK_WHISKER_CONFIG'] = prevEnv;
+    await reloadLocalGithubConfig();
+  });
+
+  it('loads config from env override and validates minimal schema', async () => {
+    const cfgPath = path.join(tempDir, 'config.yaml');
+    await writeFile(
+      cfgPath,
+      [
+        'github:',
+        '  mappings:',
+        '    - repo: foo:bar',
+        `      root: ${tempDir}`,
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    // biome-ignore lint/complexity/useLiteralKeys: environment access via index
+    process.env['BALDRICK_WHISKER_CONFIG'] = cfgPath;
+    const cfg = await loadLocalGithubConfig();
+    assert.ok(cfg.github?.mappings && cfg.github.mappings.length === 1);
+    assert.equal(cfg.github?.mappings?.[0].repo, 'foo:bar');
+  });
+
+  it('resolver returns remote for unmapped repos', async () => {
+    const cfg: LocalGithubConfig = {};
+    const res = await resolveGithubUri(
+      { owner: 'x', repo: 'y', path: 'a.txt' },
+      cfg,
+    );
+    assert.equal(res.type, 'remote');
+  });
+
+  it('resolver returns local path for mapped repo', async () => {
+    const filePath = path.join(tempDir, 'file.txt');
+    await writeFile(filePath, 'hello', 'utf8');
+    const cfg: LocalGithubConfig = {
+      github: { mappings: [{ repo: 'foo:bar', root: tempDir }] },
+    };
+    const res = await resolveGithubUri(
+      { owner: 'foo', repo: 'bar', path: 'file.txt' },
+      cfg,
+    );
+    assert.equal(res.type, 'local');
+    assert.equal(res.path, filePath);
+  });
+
+  it('resolver prevents traversal outside root', async () => {
+    const cfg: LocalGithubConfig = {
+      github: { mappings: [{ repo: 'foo:bar', root: tempDir }] },
+    };
+    await assert.rejects(
+      () =>
+        resolveGithubUri(
+          { owner: 'foo', repo: 'bar', path: '../etc/passwd' },
+          cfg,
+        ),
+      /escapes mapping root/i,
+    );
+  });
+
+  it('resolver errors when mapped file is missing', async () => {
+    const cfg: LocalGithubConfig = {
+      github: { mappings: [{ repo: 'foo:bar', root: tempDir }] },
+    };
+    await assert.rejects(
+      () =>
+        resolveGithubUri({ owner: 'foo', repo: 'bar', path: 'none.txt' }, cfg),
+      /not found/i,
+    );
+  });
+});


### PR DESCRIPTION
Bump version to 0.13.0.

- Updated version in baldrick-broth-model.yaml, package.json, and src/version.ts
- Built CLI and verified version output via `yarn cli --version`
- Ran `npx baldrick-broth@latest test all`: lint, unit tests, pest acceptance tests, coverage, and build all passed

No test changes required.